### PR TITLE
Update Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,7 @@ Vagrant.configure("2") do |config|
   end
   
   # Sync between the web root of the VM and the 'sites' directory
-  config.vm.synced_folder "sites/", "/var/www"
+  config.vm.synced_folder "sites/", "/var/www/html"
 
   forward_port[1080]      # mailcatcher
   forward_port[3306]      # mysql


### PR DESCRIPTION
Apache is configured to read files from /var/www/html . Line 20 syncs files from /vagrant/sites to /var/www , which results in an empty Root Dir while files are laying in a folder above.